### PR TITLE
feat(api): REST password recovery/reset endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## dev
 
+- New: REST password recovery flow (`api/v1/RecoveryController`): `POST recovery/request`, `GET/POST recovery/reset` with an opaque token; recovery email links to a decoupled frontend via `Module::$passwordRecoveryUrl` instead of the web route (web flow unchanged) (mp1509)
+- New: REST API login via JWT (`api/v1/SecurityController::login`), with optional post-login redirect; JWT generation lives on the User model (gabriél, mp1509)
+- New: REST API for RBAC introspection — roles and permissions scoped by privilege (`api/v1/AuthController`) (gabriél, mp1509)
+- Enh: REST login also sets the access token as an httpOnly cookie, configurable via `Module::$apiTokenCookie*`, with a raw-value option for SSR/BFF layers (mp1509)
+- Enh: Deprecated the legacy `rest/` REST controllers in favour of `api/v1/` (mp1509)
+- Enh: Set `__CLASS__` as the log category in services (AndreScara11)
+- Enh: Added UserBlockService to the Bootstrap classMap (AndreScara11)
+- Fix: Implicit nullable parameter for PHP 8.4 compatibility (TonisOrmisson)
 - Enh: Changed exception thrown in PasswordRecoveryService from `RuntimeException` to `NotFoundException`. (eseperio)
 - New #553: created Da\User\AuthClient\Microsoft365 auth client (edegaudenzi)
 - Ehh: Added SecurityHelper to the Bootstrap classMap

--- a/src/User/Controller/api/CLAUDE.md
+++ b/src/User/Controller/api/CLAUDE.md
@@ -16,6 +16,27 @@ Active REST API controllers live here (the `rest/` sibling folder is deprecated)
 - Authentication is via `JwtHttpBearerAuth` / `module->authenticatorClass`.
   Authentication alone is NOT authorization — add an explicit privilege check.
 
+## `RecoveryController` (password recovery over REST)
+
+REST twin of the web `Da\User\Controller\RecoveryController`, for a decoupled frontend.
+All actions are **public** (`authenticator` unset) — a pre-auth flow whose only credential
+is the recovery token.
+
+- `POST recovery/request` (`{ email }`) → **always** `{ ok: true }`, whether or not the
+  address is registered and whether or not the mail sent (upstream failures are only
+  logged). Never let this differ by outcome — it would enumerate users.
+- `GET recovery/reset?token=` → `{ valid: bool }`; `POST recovery/reset` (`{ token,
+  password }`) → `{ ok: true }`, or a generic `400` for a bad/expired token or an unmet
+  password rule. Never surface *why* it failed.
+- The web `(id, code)` pair travels as one opaque token — `Token::getApiToken()` /
+  `Token::splitApiToken()`.
+- **Reset link points at the frontend, not the backend.** The email URL comes from
+  `Module::$passwordRecoveryUrl` (a `{token}` template) via
+  `PasswordRecoveryService::setResetUrlTemplate()`. This is backend config on purpose: the
+  link host must never be client-supplied (reset-email host injection → phishing). When the
+  property is unset, the request action logs an error and still returns `{ ok: true }`.
+- The recovery token is **deleted after a successful reset** (single use, no replay).
+
 ## `SecurityController::actionLogin`
 
 - Token value comes from `User::getAccessToken()` (base impl throws `NotSupportedException`;

--- a/src/User/Controller/api/v1/RecoveryController.php
+++ b/src/User/Controller/api/v1/RecoveryController.php
@@ -1,0 +1,193 @@
+<?php
+
+/*
+ * This file is part of the 2amigos/yii2-usuario project.
+ *
+ * (c) 2amigOS! <http://2amigos.us/>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Da\User\Controller\api\v1;
+
+use Da\User\Event\FormEvent;
+use Da\User\Factory\MailFactory;
+use Da\User\Form\RecoveryForm;
+use Da\User\Model\Token;
+use Da\User\Query\TokenQuery;
+use Da\User\Query\UserQuery;
+use Da\User\Service\PasswordRecoveryService;
+use Da\User\Service\ResetPasswordService;
+use Da\User\Traits\ContainerAwareTrait;
+use Da\User\Traits\ModuleAwareTrait;
+use Yii;
+use yii\rest\Controller;
+use yii\web\BadRequestHttpException;
+use yii\web\NotFoundHttpException;
+
+/**
+ * REST twin of {@see \Da\User\Controller\RecoveryController}: drives the whole
+ * password-recovery flow over the API so a decoupled frontend (SPA/BFF) can own it.
+ *
+ * - `POST recovery/request` — `{ email }` → send the recovery email, always `{ ok: true }`.
+ * - `GET  recovery/reset?token=` → `{ valid: bool }` (validate before showing the form).
+ * - `POST recovery/reset` — `{ token, password }` → set the new password.
+ *
+ * The `(id, code)` pair the web flow uses is carried as one opaque {@see Token::getApiToken()
+ * token}. The recovery email links to {@see \Da\User\Module::$passwordRecoveryUrl} (the
+ * frontend), not the backend web route. Responses never reveal whether an address is
+ * registered or why a token failed (no user enumeration).
+ */
+class RecoveryController extends Controller
+{
+    use ContainerAwareTrait;
+    use ModuleAwareTrait;
+
+    protected $userQuery;
+    protected $tokenQuery;
+
+    public function __construct($id, $module, UserQuery $userQuery, TokenQuery $tokenQuery, array $config = [])
+    {
+        $this->userQuery = $userQuery;
+        $this->tokenQuery = $tokenQuery;
+        parent::__construct($id, $module, $config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+
+        // Recovery is a pre-authentication flow: the recovery token is the only credential.
+        unset($behaviors['authenticator']);
+
+        return $behaviors;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function verbs()
+    {
+        return [
+            'request' => ['POST'],
+            'reset' => ['GET', 'POST'],
+        ];
+    }
+
+    /**
+     * Requests a recovery email. Always reports success, whether or not the address maps to an
+     * account, so the endpoint cannot enumerate registered users.
+     *
+     * @throws NotFoundHttpException when recovery is disabled on the module
+     * @return array
+     */
+    public function actionRequest()
+    {
+        if (!$this->module->allowPasswordRecovery) {
+            throw new NotFoundHttpException();
+        }
+
+        /** @var RecoveryForm $form */
+        $form = $this->make(RecoveryForm::class, [], ['scenario' => RecoveryForm::SCENARIO_REQUEST]);
+        $form->load(Yii::$app->request->getBodyParams(), '');
+
+        if ($form->validate()) {
+            /** @var FormEvent $event */
+            $event = $this->make(FormEvent::class, [$form]);
+            $this->trigger(FormEvent::EVENT_BEFORE_REQUEST, $event);
+
+            if (empty($this->module->passwordRecoveryUrl)) {
+                // Without a frontend reset URL the email link would point at the backend web
+                // route, defeating the API flow. Log and fall through to the generic response.
+                Yii::error(
+                    'API password recovery requested but Module::$passwordRecoveryUrl is not configured.',
+                    __METHOD__
+                );
+            } else {
+                $mailService = MailFactory::makeRecoveryMailerService($form->email);
+                $service = $this->make(PasswordRecoveryService::class, [$form->email, $mailService]);
+                $service->setResetUrlTemplate($this->module->passwordRecoveryUrl);
+                if ($service->run()) {
+                    $this->trigger(FormEvent::EVENT_AFTER_REQUEST, $event);
+                }
+            }
+        }
+
+        return ['ok' => true];
+    }
+
+    /**
+     * `GET`  — validates a recovery token (`?token=`) → `{ valid: bool }`.
+     * `POST` — sets a new password (`{ token, password }`) → `{ ok: true }`.
+     *
+     * @throws NotFoundHttpException when recovery is disabled on the module
+     * @throws BadRequestHttpException on an invalid/expired token or an unmet password rule
+     * @return array
+     */
+    public function actionReset()
+    {
+        if (!$this->module->allowPasswordRecovery) {
+            throw new NotFoundHttpException();
+        }
+
+        $request = Yii::$app->request;
+
+        if ($request->getIsGet()) {
+            return ['valid' => $this->findRecoveryToken($request->get('token')) !== null];
+        }
+
+        $body = $request->getBodyParams();
+
+        $token = $this->findRecoveryToken($body['token'] ?? null);
+        if ($token === null) {
+            throw new BadRequestHttpException(Yii::t('usuario', 'Recovery link is invalid or expired. Please try requesting a new one.'));
+        }
+
+        /** @var RecoveryForm $form */
+        $form = $this->make(RecoveryForm::class, [], ['scenario' => RecoveryForm::SCENARIO_RESET]);
+        $form->password = $body['password'] ?? null;
+
+        if (!$form->validate()) {
+            $errors = $form->getFirstErrors();
+            throw new BadRequestHttpException($errors ? reset($errors) : Yii::t('usuario', 'Password reset failed'));
+        }
+
+        if (!$this->make(ResetPasswordService::class, [$form->password, $token->user])->run()) {
+            throw new BadRequestHttpException(Yii::t('usuario', 'Password reset failed'));
+        }
+
+        // Single use: drop the token so the link cannot be replayed.
+        $token->delete();
+
+        return ['ok' => true];
+    }
+
+    /**
+     * Resolves an opaque API token to a live, non-expired recovery {@see Token} whose user still
+     * exists, or `null`. A malformed token, a missing row, expiry or a dangling user all collapse
+     * to `null` so callers cannot distinguish the failure modes.
+     *
+     * @param mixed $apiToken
+     * @return Token|null
+     */
+    protected function findRecoveryToken($apiToken)
+    {
+        [$userId, $code] = Token::splitApiToken($apiToken);
+        if ($userId === null) {
+            return null;
+        }
+
+        /** @var Token|null $token */
+        $token = $this->tokenQuery->whereUserId($userId)->whereCode($code)->whereIsRecoveryType()->one();
+
+        if ($token === null || $token->getIsExpired() || $token->user === null) {
+            return null;
+        }
+
+        return $token;
+    }
+}

--- a/src/User/Model/Token.php
+++ b/src/User/Model/Token.php
@@ -100,6 +100,42 @@ class Token extends ActiveRecord
     }
 
     /**
+     * Opaque single-string form of the token, for clients (e.g. a decoupled SPA) that carry it
+     * as one value instead of the `(id, code)` pair the web routes use.
+     *
+     * `code` is a base64url random string (`[A-Za-z0-9_-]`, never a `.`), so `"{user_id}.{code}"`
+     * is unambiguous to split. Only `user_id` is exposed (already public in the web reset URL);
+     * the secret remains `code`.
+     *
+     * @return string
+     */
+    public function getApiToken()
+    {
+        return $this->user_id . '.' . $this->code;
+    }
+
+    /**
+     * Splits an {@see getApiToken() opaque API token} back into `[userId, code]`.
+     * Returns `[null, null]` for any malformed input, so callers can treat "unparseable"
+     * and "no matching token" identically (no detail leak).
+     *
+     * @param mixed $token
+     * @return array{0: int|null, 1: string|null}
+     */
+    public static function splitApiToken($token)
+    {
+        if (!is_string($token) || strpos($token, '.') === false) {
+            return [null, null];
+        }
+        [$userId, $code] = explode('.', $token, 2);
+        if (!ctype_digit($userId) || $code === '') {
+            return [null, null];
+        }
+
+        return [(int) $userId, $code];
+    }
+
+    /**
      * @throws RuntimeException
      * @return bool             Whether token has expired
      */

--- a/src/User/Module.php
+++ b/src/User/Module.php
@@ -305,6 +305,12 @@ class Module extends BaseModule
         'GET permissions' => 'api/v1/auth/permissions',
         'GET roles-by-user' => 'api/v1/auth/roles-by-user',
         'GET permissions-by-user' => 'api/v1/auth/permissions-by-user',
+        // Value is the controller/action relative to the `api/v1` the routePrefix already adds
+        // (cf. adminRestRoutes' `admin/index`), so URL `user/api/v1/recovery/*` → route
+        // `user/api/v1/recovery/*` → Da\User\Controller\api\v1\RecoveryController.
+        'POST recovery/request' => 'recovery/request',
+        'GET recovery/reset' => 'recovery/reset',
+        'POST recovery/reset' => 'recovery/reset',
     ];
 
     /**
@@ -342,6 +348,22 @@ class Module extends BaseModule
      * set — wraps the value in Yii's signed/serialized envelope (readable only by this app).
      */
     public $apiTokenCookieRaw = false;
+
+    /**
+     * @var string|null Reset-link template for the **API** password-recovery flow
+     * ({@see \Da\User\Controller\api\v1\RecoveryController}). An absolute URL to a decoupled
+     * frontend's reset page containing a `{token}` placeholder, e.g.
+     * `https://app.example.com/auth/reset?token={token}`; `{token}` is replaced with the recovery
+     * token's {@see \Da\User\Model\Token::getApiToken() opaque form}.
+     *
+     * This is intentionally **backend configuration**, never a value supplied by the client: a
+     * reset link is emailed to the account owner, so its host must be authoritative and cannot be
+     * influenced by the caller (otherwise a request for someone else's address could carry a
+     * phishing link). When `null`, the API request-recovery action cannot build a usable link and
+     * logs an error while still returning a generic success (no user enumeration). The web flow is
+     * unaffected — it keeps using `Token::getUrl()`.
+     */
+    public $passwordRecoveryUrl = null;
 
     /**
      * @return string with the hit to be used with the give consent checkbox

--- a/src/User/Service/PasswordRecoveryService.php
+++ b/src/User/Service/PasswordRecoveryService.php
@@ -32,11 +32,34 @@ class PasswordRecoveryService implements ServiceInterface
     protected $mailService;
     protected $securityHelper;
 
+    /**
+     * @var string|null Optional reset-link template with a `{token}` placeholder. When set, the
+     * recovery email links to this URL (a decoupled frontend's reset page) instead of the backend
+     * web route. See {@see setResetUrlTemplate()}.
+     */
+    protected $resetUrlTemplate;
+
     public function __construct($email, MailService $mailService, UserQuery $query)
     {
         $this->email = $email;
         $this->mailService = $mailService;
         $this->query = $query;
+    }
+
+    /**
+     * Points the recovery email at a decoupled frontend's reset page instead of the backend web
+     * route. `$template` is an absolute URL containing a `{token}` placeholder, replaced with the
+     * token's {@see \Da\User\Model\Token::getApiToken() opaque form}. Leave unset (the default) to
+     * keep the built-in web link (`$token->url`).
+     *
+     * @param string|null $template
+     * @return $this
+     */
+    public function setResetUrlTemplate($template)
+    {
+        $this->resetUrlTemplate = $template;
+
+        return $this;
     }
 
     public function run()
@@ -62,6 +85,12 @@ class PasswordRecoveryService implements ServiceInterface
 
             $this->mailService->setViewParam('user', $user);
             $this->mailService->setViewParam('token', $token);
+            if (!empty($this->resetUrlTemplate)) {
+                $this->mailService->setViewParam(
+                    'resetUrl',
+                    strtr($this->resetUrlTemplate, ['{token}' => $token->apiToken])
+                );
+            }
             if (!$this->sendMail($user)) {
                 return false;
             }

--- a/src/User/resources/views/mail/recovery.php
+++ b/src/User/resources/views/mail/recovery.php
@@ -14,7 +14,9 @@ use yii\helpers\Html;
 /**
  * @var \Da\User\Model\User  $user
  * @var \Da\User\Model\Token $token
+ * @var string|null          $resetUrl Frontend reset link; falls back to the backend web route.
  */
+$link = !empty($resetUrl) ? $resetUrl : $token->url;
 ?>
 <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0;">
     <?= Yii::t('usuario', 'Hello') ?>,
@@ -28,7 +30,7 @@ use yii\helpers\Html;
     <?= Yii::t('usuario', 'Please click the link below to complete your password reset') ?>.
 </p>
 <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0;">
-    <?= Html::a(Html::encode($token->url), $token->url); ?>
+    <?= Html::a(Html::encode($link), $link); ?>
 </p>
 <p style="font-family: 'Helvetica Neue', 'Helvetica', Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.6; font-weight: normal; margin: 0 0 10px; padding: 0;">
     <?= Yii::t('usuario', 'If you cannot click the link, please try pasting the text into your browser') ?>.

--- a/src/User/resources/views/mail/text/recovery.php
+++ b/src/User/resources/views/mail/text/recovery.php
@@ -11,14 +11,16 @@
 
 /**
  * @var \Da\User\Model\Token $token
+ * @var string|null          $resetUrl Frontend reset link; falls back to the backend web route.
  */
+$link = !empty($resetUrl) ? $resetUrl : $token->url;
 ?>
 <?= Yii::t('usuario', 'Hello') ?>,
 
 <?= Yii::t('usuario', 'We have received a request to reset the password for your account on {0}', Yii::$app->name) ?>.
 <?= Yii::t('usuario', 'Please click the link below to complete your password reset') ?>.
 
-<?= $token->url ?>
+<?= $link ?>
 
 <?= Yii::t('usuario', 'If you cannot click the link, please try pasting the text into your browser') ?>.
 


### PR DESCRIPTION
Add Da\User\Controller\api\v1\RecoveryController exposing the password recovery flow over REST for decoupled frontends (SPA/BFF):

- POST recovery/request  ({ email })          -> always { ok: true } (no user enumeration)
- GET  recovery/reset?token=                  -> { valid: bool }
- POST recovery/reset    ({ token, password }) -> { ok: true } | generic 400

The web flow's (id, code) pair travels as one opaque token (Token::getApiToken / Token::splitApiToken). The recovery email links to a decoupled frontend's reset page via the new Module::$passwordRecoveryUrl template (PasswordRecoveryService::setResetUrlTemplate) instead of the backend web route. That URL is backend configuration, never client-supplied, to avoid reset-email host injection.

The web recovery flow is untouched: the template defaults to null and the mail views fall back to Token::url, so a request originating from the Yii2 web app still gets the backend link. The recovery token is single-use (deleted after a successful reset).

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
